### PR TITLE
Fix build of published Versions on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "wiki-tui"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiki-tui"
-version = "0.4.5"
+version = "0.4.7"
 authors = ["builditluc <37375448+Builditluc@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/Builditluc/wiki-tui"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,10 @@
 use crate::cli::Cli;
 
-use anyhow::*;
+use anyhow::{
+    Result,
+    Context,
+    bail
+};
 use cursive::theme::{BaseColor, Color};
 use lazy_static::*;
 use log::LevelFilter;


### PR DESCRIPTION
v0.4.5-v0.4.6 failed to build when installing it from crates.io (#18). This error is caused by the crate anyhow because I imported it via wildcard importing (https://github.com/dtolnay/anyhow/issues/201). This PR fixes the error.

A fixed version v0.4.7 is now published on crates.io