### PR TITLE
Add an option for selecting a different backend

### DIFF
--- a/.github/deadpendency.yaml
+++ b/.github/deadpendency.yaml
@@ -1,3 +1,4 @@
 ignore-failures:
   rust:
     - lazy_static
+    - select

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,12 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "maplit",
+ "ncurses",
+ "pancurses",
  "signal-hook 0.3.10",
+ "term_size",
+ "termion",
  "unicode-segmentation",
  "unicode-width",
  "wasmer_enumset",
@@ -766,6 +771,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "markup5ever"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ncurses"
+version = "5.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5d34d72657dc4b638a1c25d40aae81e4f1c699062f72f467237920752032"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "object"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1042,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pancurses"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3058bc37c433096b2ac7afef1c5cdfae49ede0a4ffec3dfc1df1df0959d0ff0"
+dependencies = [
+ "libc",
+ "log",
+ "ncurses",
+ "pdcurses-sys",
+ "winreg 0.5.1",
+]
+
+[[package]]
 name = "panic-message"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1083,16 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "pdcurses-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084dd22796ff60f1225d4eb6329f33afaf4c85419d51d440ab6b8c6f4529166b"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1267,6 +1318,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall 0.2.10",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,7 +1394,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -1624,6 +1684,28 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall 0.2.10",
+ "redox_termios",
 ]
 
 [[package]]
@@ -2037,6 +2119,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,13 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["crossterm-backend"]
+ncurses-backend = ["cursive/ncurses-backend"]
+pancurses-backend = ["cursive/pancurses-backend"]
+termion-backend = ["cursive/termion-backend"]
+crossterm-backend = ["cursive/crossterm-backend"]
+
 [dependencies]
 syn = "=1.0.57"
 serde_json = "1.0.61"
@@ -28,7 +35,6 @@ structopt = "0.3.25"
 [dependencies.cursive]
 version = "0.16.3"
 default-features = false
-features = ["crossterm-backend"]
 
 [dependencies.reqwest]
 version = "0.11"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The binary executable is `wiki-tui`
 cargo install wiki-tui
 ```
 
-When installing wiki-tui via cargo, you can choose what backend to use. More information on the
+When installing wiki-tui via cargo, you can choose what backend to use (The default one is crossterm). More information on the
 available backends can be found [here](https://github.com/gyscos/cursive/wiki/Backends#available-backends)
 
 To use a different backend, you will have to disable the default features and enable the desired backend feature.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@
   </p>
 </p>
 
-# Breaking Changes to the branching system!
-The experimental and stable branch are now removed and replaced by a single main branch. Also, the changelog file is gone and replaced by the release notes. If you want to know how to contribute to wiki-tui, you can read about it [here](./CONTRIBUTING.md).
-
 ## Preview
 ### How it looks
 
@@ -50,6 +47,15 @@ The binary executable is `wiki-tui`
 ```
 cargo install wiki-tui
 ```
+
+When installing wiki-tui via cargo, you can choose what backend to use. More information on the
+available backends can be found [here](https://github.com/gyscos/cursive/wiki/Backends#available-backends)
+
+To use a different backend, you will have to disable the default features and enable the desired backend feature.
+```
+cargo install wiki-tui --no-default-features --features termion-backend
+```
+
 ### NetBSD
 Using the package manager
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,6 @@
 use crate::cli::Cli;
 
-use anyhow::{
-    Result,
-    Context,
-    bail
-};
+use anyhow::{bail, Context, Result};
 use cursive::theme::{BaseColor, Color};
 use lazy_static::*;
 use log::LevelFilter;


### PR DESCRIPTION
This feature will allow users to specify the backend used by cursive when installing wiki-tui