### PR TITLE
Add option to change the keybindings via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,46 @@ log_level = "Info"                      # log level to be used, can be Debug, In
 [features]
 links = true                            # enables/disables links (link selection, link opening, etc)
 headers = true                          # enables/disables header selection
+
+# You can change the keybindings of certain actions
+# These are the default values
+[keybindings]
+down.key = ""
+# Here you can define the key, it can be a simple character or a non-character key
+# Supported non-character Keys (lower-/uppercase do not matter):
+# - insert
+# - delete
+# - home
+# - end
+# - pageup
+# - pagedown
+# - pausebreak
+# - numpadcenter
+# - f0 - f12
+
+down.mode = "normal"
+# Here you can change the mode of the keybinding. The standard mode is normal and doesn't need to be set.
+# This value is optional and the following modes are available:
+# Characters:
+# - normal
+# - ctrl
+# Non-Character Keys:
+# - normal
+# - shift
+# - alt
+# - altshift
+# - ctrl
+# - ctrlshift
+# - ctrlalt
+
+
+# Currently, these actions can be changed with a keybinding:
+# - down
+# - up
+# - left
+# - right
+
+# Note: the default keys (Up, Down, Left, Right) will still work even after changing the keybinding.
 ```
 
 ## Contributing

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,9 +124,9 @@ fn start_application() {
         .with_name("logo_view")
         .full_screen();
 
-    let article_layout = LinearLayout::horizontal()
+    let article_layout = override_keybindings!(LinearLayout::horizontal()
         .child(Dialog::around(logo_view))
-        .with_name("article_layout");
+        .with_name("article_layout"));
 
     // Add a fullscreen layer, containing the search bar and the article view
     siv.add_fullscreen_layer(

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config, ui, view_with_theme,
+    config, override_keybindings, ui, view_with_theme,
     wiki::search::{
         SearchBuilder, SearchMetadata, SearchProperties, SearchResult, SearchSortOrder,
     },
@@ -102,16 +102,14 @@ pub fn on_search(siv: &mut Cursive, search_query: String) {
     let search_results_layout = LinearLayout::horizontal()
         .child(view_with_theme!(
             config::CONFIG.theme.search_results,
-            Dialog::around(
-                LinearLayout::vertical()
-                    .child(
-                        search_results_view
-                            .with_name("search_results_view")
-                            .scrollable()
-                            .min_height(10)
-                    )
-                    .child(search_continue_button),
-            )
+            Dialog::around(override_keybindings!(LinearLayout::vertical()
+                .child(
+                    search_results_view
+                        .with_name("search_results_view")
+                        .scrollable()
+                        .min_height(10)
+                )
+                .child(search_continue_button)),)
         ))
         .child(view_with_theme!(
             config::CONFIG.theme.search_preview,

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -26,3 +26,36 @@ macro_rules! view_with_theme {
         }
     };
 }
+
+/// Wraps a view into a OnEventView that overrides the keybindings of the view with the ones
+/// defined in the config
+#[macro_export]
+macro_rules! override_keybindings {
+    ($view: expr) => {
+        cursive::views::OnEventView::new($view)
+            .on_pre_event(
+                config::CONFIG.keybindings.down.clone(),
+                |siv: &mut cursive::Cursive| {
+                    siv.on_event(cursive::event::Event::Key(cursive::event::Key::Down))
+                },
+            )
+            .on_pre_event(
+                cursive::event::Event::Char('k'),
+                |siv: &mut cursive::Cursive| {
+                    siv.on_event(cursive::event::Event::Key(cursive::event::Key::Up))
+                },
+            )
+            .on_pre_event(
+                cursive::event::Event::Char('h'),
+                |siv: &mut cursive::Cursive| {
+                    siv.on_event(cursive::event::Event::Key(cursive::event::Key::Left))
+                },
+            )
+            .on_pre_event(
+                cursive::event::Event::Char('l'),
+                |siv: &mut cursive::Cursive| {
+                    siv.on_event(cursive::event::Event::Key(cursive::event::Key::Right))
+                },
+            )
+    };
+}


### PR DESCRIPTION
As requested in #37, this feature adds the option to change the keybindings of certain actions via the configuration file. Currently, the following actions are implemented:

- up
- down
- left
- right

More are planned for the future.