### PR TITLE
Update Bug Report Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,6 +7,12 @@ assignees: ''
 
 ---
 
+**General Information**
+Version: 
+Installation Method:
+Operating System:
+Backend (If changed during install):
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
As pointed out in #39 a section for general information (like version and installation method) is missing in the current bug report issue template. This adds the section