### PR TITLE
Increase Stale Days to 365

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,4 @@
-daysUntilStale: 60
+daysUntilStale: 365
 daysUntilClose: 7
 exemptLabels:
   - pinned


### PR DESCRIPTION
This PR increases the number of days an issue can be stale before it's marked as "stale" to 365 days from the previous 60 days