### PR TITLE
Add toc position setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ down.mode = "normal"
 # - right
 
 # Note: the default keys (Up, Down, Left, Right) will still work even after changing the keybinding.
+
+# [PRE-RELEASE] These options haven't been released yet
+# You can change different settings here
+[settings]
+toc_position = "left"                    # Here you can change the position of the toc view. Available options are "left" and "right" (default).
 ```
 
 ## Contributing

--- a/src/ui/article/mod.rs
+++ b/src/ui/article/mod.rs
@@ -6,7 +6,10 @@ use crate::wiki::{
     },
     search::SearchResult,
 };
-use crate::{config, ui, view_with_theme};
+use crate::{
+    config::{self, TocPosition, CONFIG},
+    ui, view_with_theme,
+};
 
 use anyhow::{bail, Context, Result};
 use cursive::align::HAlign;
@@ -188,12 +191,18 @@ fn display_article(siv: &mut Cursive, article: Article) -> Result<()> {
     let article_view = ArticleView::new(article);
     log::debug!("created an instance of ArticleView");
 
+    // get the index of the article view (this index determines the location of the toc)
+    let index = match CONFIG.settings.toc_position {
+        TocPosition::LEFT => 1,
+        TocPosition::RIGHT => 0,
+    };
+
     // add the article view to the screen
     let result = siv.call_on_name("article_layout", |view: &mut LinearLayout| {
         view.insert_child(
-            0,
+            index,
             view_with_theme!(
-                config::CONFIG.theme.article_view,
+                CONFIG.theme.article_view,
                 Dialog::around(article_view.with_name("article_view").scrollable())
             ),
         );


### PR DESCRIPTION
This adds the following configuration option
```toml
[settings]
toc_position = "left" | "right"
```
The default for this option is `right` and changing it moves the toc to the corresponding position (only if the toc is enabled, of course)