### PR TITLE
Add more toc settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ position = "right"
 # - custom  (uses the title configured in the option "title_custom", if "title_custom" is empty, it will display "NONE")
 title = "default"
 title_custom = "My Custom Title"
+# By default, there are horizontal and vertical scrollbars that appear when there isn't enough space for the toc. 
+#If you don't want these scrollbars, you can disable them.
+scroll_x = true
+scroll_y = true
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ position = "right"
 # - custom  (uses the title configured in the option "title_custom", if "title_custom" is empty, it will display "NONE")
 title = "default"
 title_custom = "My Custom Title"
+# You can also change the min and max width of the toc view. The defaults are 20 for the min width and 60 for the max width
+min_width = 20
+max_width = 60
+
 # By default, there are horizontal and vertical scrollbars that appear when there isn't enough space for the toc. 
 #If you don't want these scrollbars, you can disable them.
 scroll_x = true

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ down.mode = "normal"
 
 # [PRE-RELEASE] These options haven't been released yet
 # You can change different settings here
-[settings]
-toc_position = "left"                    # Here you can change the position of the toc view. Available options are "left" and "right" (default).
+[settings.toc]
+position = "right"                   # Here you can change the position of the toc view. Available options are "left" and "right" (default).
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -180,7 +180,14 @@ down.mode = "normal"
 # [PRE-RELEASE] These options haven't been released yet
 # You can change different settings here
 [settings.toc]
-position = "right"                   # Here you can change the position of the toc view. Available options are "left" and "right" (default).
+# Here you can change the position of the toc view. Available options are "left" and "right" (default).
+position = "right"
+# You can change the title of the table of contents, the available options are
+# - default (uses the toc title given by the article)
+# - article (uses the title of the article you are viewing)
+# - custom  (uses the title configured in the option "title_custom", if "title_custom" is empty, it will display "NONE")
+title = "default"
+title_custom = "My Custom Title"
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ title_custom = "My Custom Title"
 #If you don't want these scrollbars, you can disable them.
 scroll_x = true
 scroll_y = true
+# You can also change how the items are generated. Available values are
+# - {NUMBER} : current number of the header (1, 1.1, 1.2, 2, ...)
+# - {TEXT}   : text of the header
+item_format = "{NUMBER} {TEXT}"
 ```
 
 ## Contributing

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,7 @@ pub struct TocSettings {
     pub title_custom: Option<String>,
     pub scroll_x: bool,
     pub scroll_y: bool,
+    pub item_format: String,
 }
 
 pub enum TocPosition {
@@ -169,6 +170,7 @@ struct UserTocSettings {
     title_custom: Option<String>,
     scroll_x: Option<bool>,
     scroll_y: Option<bool>,
+    item_format: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -276,6 +278,7 @@ impl Config {
                     title_custom: None,
                     scroll_x: true,
                     scroll_y: true,
+                    item_format: "{NUMBER} {TEXT}".to_string(),
                 },
             },
             config_path: PathBuf::new(),
@@ -647,6 +650,10 @@ impl Config {
 
         if let Some(scroll_y) = &user_toc_settings.scroll_y {
             self.settings.toc.scroll_y = scroll_y.to_owned();
+        }
+
+        if let Some(item_format) = &user_toc_settings.item_format {
+            self.settings.toc.item_format = item_format.to_owned();
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,11 +119,19 @@ pub struct Settings {
 
 pub struct TocSettings {
     pub position: TocPosition,
+    pub title: TocTitle,
+    pub title_custom: Option<String>,
 }
 
 pub enum TocPosition {
     LEFT,
     RIGHT,
+}
+
+pub enum TocTitle {
+    DEFAULT,
+    CUSTOM,
+    ARTICLE,
 }
 
 pub struct Config {
@@ -155,6 +163,8 @@ struct UserSettings {
 #[derive(Deserialize, Debug)]
 struct UserTocSettings {
     position: Option<String>,
+    title: Option<String>,
+    title_custom: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -256,7 +266,11 @@ impl Config {
                 right: None,
             },
             settings: Settings {
-                toc: TocSettings { position: TocPosition::RIGHT, },
+                toc: TocSettings {
+                    position: TocPosition::RIGHT,
+                    title: TocTitle::DEFAULT,
+                    title_custom: None,
+                },
             },
             config_path: PathBuf::new(),
             args: Cli::from_args(),
@@ -606,6 +620,19 @@ impl Config {
                 "right" => self.settings.toc.position = TocPosition::RIGHT,
                 pos => log::warn!("unknown toc position, got {}", pos),
             }
+        }
+
+        if let Some(title) = &user_toc_settings.title {
+            match title.to_lowercase().as_str() {
+                "default" => self.settings.toc.title = TocTitle::DEFAULT,
+                "custom" => self.settings.toc.title = TocTitle::CUSTOM,
+                "article" => self.settings.toc.title = TocTitle::ARTICLE,
+                _ => self.settings.toc.title = TocTitle::DEFAULT,
+            }
+        }
+
+        if let Some(title_custom) = &user_toc_settings.title_custom {
+            self.settings.toc.title_custom = Some(title_custom.to_string());
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,11 @@ pub struct Keybindings {
 }
 
 pub struct Settings {
-    pub toc_position: TocPosition,
+    pub toc: TocSettings,
+}
+
+pub struct TocSettings {
+    pub position: TocPosition,
 }
 
 pub enum TocPosition {
@@ -145,7 +149,12 @@ struct UserConfig {
 
 #[derive(Deserialize, Debug)]
 struct UserSettings {
-    toc_position: Option<String>,
+    toc: Option<UserTocSettings>,
+}
+
+#[derive(Deserialize, Debug)]
+struct UserTocSettings {
+    position: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -247,7 +256,7 @@ impl Config {
                 right: None,
             },
             settings: Settings {
-                toc_position: TocPosition::RIGHT,
+                toc: TocSettings { position: TocPosition::RIGHT, },
             },
             config_path: PathBuf::new(),
             args: Cli::from_args(),
@@ -583,10 +592,18 @@ impl Config {
     fn load_settings(&mut self, user_settings: &UserSettings) {
         log::info!("loading settings");
 
-        if let Some(position) = &user_settings.toc_position {
+        if let Some(user_toc_settings) = &user_settings.toc {
+            self.load_toc_settings(user_toc_settings);
+        }
+    }
+
+    fn load_toc_settings(&mut self, user_toc_settings: &UserTocSettings) {
+        log::info!("loading toc settings");
+
+        if let Some(position) = &user_toc_settings.position {
             match position.to_lowercase().as_str() {
-                "left" => self.settings.toc_position = TocPosition::LEFT,
-                "right" => self.settings.toc_position = TocPosition::RIGHT,
+                "left" => self.settings.toc.position = TocPosition::LEFT,
+                "right" => self.settings.toc.position = TocPosition::RIGHT,
                 pos => log::warn!("unknown toc position, got {}", pos),
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,8 @@ pub struct TocSettings {
     pub position: TocPosition,
     pub title: TocTitle,
     pub title_custom: Option<String>,
+    pub min_width: usize,
+    pub max_width: usize,
     pub scroll_x: bool,
     pub scroll_y: bool,
     pub item_format: String,
@@ -168,6 +170,8 @@ struct UserTocSettings {
     position: Option<String>,
     title: Option<String>,
     title_custom: Option<String>,
+    min_width: Option<usize>,
+    max_width: Option<usize>,
     scroll_x: Option<bool>,
     scroll_y: Option<bool>,
     item_format: Option<String>,
@@ -276,6 +280,8 @@ impl Config {
                     position: TocPosition::RIGHT,
                     title: TocTitle::DEFAULT,
                     title_custom: None,
+                    min_width: 20,
+                    max_width: 60,
                     scroll_x: true,
                     scroll_y: true,
                     item_format: "{NUMBER} {TEXT}".to_string(),
@@ -642,6 +648,14 @@ impl Config {
 
         if let Some(title_custom) = &user_toc_settings.title_custom {
             self.settings.toc.title_custom = Some(title_custom.to_string());
+        }
+
+        if let Some(min_width) = &user_toc_settings.min_width {
+            self.settings.toc.min_width = min_width.to_owned();
+        }
+
+        if let Some(max_width) = &user_toc_settings.max_width {
+            self.settings.toc.max_width = max_width.to_owned();
         }
 
         if let Some(scroll_x) = &user_toc_settings.scroll_x {

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,8 @@ pub struct TocSettings {
     pub position: TocPosition,
     pub title: TocTitle,
     pub title_custom: Option<String>,
+    pub scroll_x: bool,
+    pub scroll_y: bool,
 }
 
 pub enum TocPosition {
@@ -165,6 +167,8 @@ struct UserTocSettings {
     position: Option<String>,
     title: Option<String>,
     title_custom: Option<String>,
+    scroll_x: Option<bool>,
+    scroll_y: Option<bool>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -270,6 +274,8 @@ impl Config {
                     position: TocPosition::RIGHT,
                     title: TocTitle::DEFAULT,
                     title_custom: None,
+                    scroll_x: true,
+                    scroll_y: true,
                 },
             },
             config_path: PathBuf::new(),
@@ -633,6 +639,14 @@ impl Config {
 
         if let Some(title_custom) = &user_toc_settings.title_custom {
             self.settings.toc.title_custom = Some(title_custom.to_string());
+        }
+
+        if let Some(scroll_x) = &user_toc_settings.scroll_x {
+            self.settings.toc.scroll_x = scroll_x.to_owned();
+        }
+
+        if let Some(scroll_y) = &user_toc_settings.scroll_y {
+            self.settings.toc.scroll_y = scroll_y.to_owned();
         }
     }
 

--- a/src/ui/article/mod.rs
+++ b/src/ui/article/mod.rs
@@ -187,18 +187,22 @@ fn display_article(siv: &mut Cursive, article: Article) -> Result<()> {
         ui::toc::add_table_of_contents(siv, toc);
     }
 
+    // check if the article has a toc
+    let has_toc = article.toc().is_some();
+
     // create the article view
     let article_view = ArticleView::new(article);
     log::debug!("created an instance of ArticleView");
 
     // get the index of the article view (this index determines the location of the toc)
-    let index = match CONFIG.settings.toc_position {
+    let index = match CONFIG.settings.toc.position {
         TocPosition::LEFT => 1,
         TocPosition::RIGHT => 0,
     };
 
     // add the article view to the screen
     let result = siv.call_on_name("article_layout", |view: &mut LinearLayout| {
+        if CONFIG.features.toc && has_toc {
         view.insert_child(
             index,
             view_with_theme!(
@@ -206,6 +210,14 @@ fn display_article(siv: &mut Cursive, article: Article) -> Result<()> {
                 Dialog::around(article_view.with_name("article_view").scrollable())
             ),
         );
+        } else {
+            view.add_child(
+                view_with_theme!(
+                    CONFIG.theme.article_view,
+                    Dialog::around(article_view.with_name("article_view").scrollable())
+                ),
+            );
+        }
     });
     if result.is_none() {
         log::debug!("display_article failed to finish");

--- a/src/ui/article/mod.rs
+++ b/src/ui/article/mod.rs
@@ -203,20 +203,18 @@ fn display_article(siv: &mut Cursive, article: Article) -> Result<()> {
     // add the article view to the screen
     let result = siv.call_on_name("article_layout", |view: &mut LinearLayout| {
         if CONFIG.features.toc && has_toc {
-        view.insert_child(
-            index,
-            view_with_theme!(
-                CONFIG.theme.article_view,
-                Dialog::around(article_view.with_name("article_view").scrollable())
-            ),
-        );
-        } else {
-            view.add_child(
+            view.insert_child(
+                index,
                 view_with_theme!(
                     CONFIG.theme.article_view,
                     Dialog::around(article_view.with_name("article_view").scrollable())
                 ),
             );
+        } else {
+            view.add_child(view_with_theme!(
+                CONFIG.theme.article_view,
+                Dialog::around(article_view.with_name("article_view").scrollable())
+            ));
         }
     });
     if result.is_none() {

--- a/src/ui/toc.rs
+++ b/src/ui/toc.rs
@@ -58,18 +58,22 @@ pub fn add_table_of_contents(siv: &mut Cursive, toc: &TableOfContents) {
         add_item_to_toc(&mut toc_view, item);
     }
 
-    article_layout.add_child(view_with_theme!(
-        config::CONFIG.theme.toc_view,
-        Dialog::around(
-            toc_view
-                .with_name("toc_view")
-                .scrollable()
-                .scroll_x(config::CONFIG.settings.toc.scroll_x)
-                .scroll_y(config::CONFIG.settings.toc.scroll_y)
-                .full_height()
+    article_layout.add_child(
+        view_with_theme!(
+            config::CONFIG.theme.toc_view,
+            Dialog::around(
+                toc_view
+                    .with_name("toc_view")
+                    .scrollable()
+                    .scroll_x(config::CONFIG.settings.toc.scroll_x)
+                    .scroll_y(config::CONFIG.settings.toc.scroll_y)
+                    .full_height()
+            )
+            .title(toc.title())
         )
-        .title(toc.title())
-    ));
+        .min_width(config::CONFIG.settings.toc.min_width)
+        .max_width(config::CONFIG.settings.toc.max_width),
+    );
 
     log::debug!("added the toc_view to the article_layout");
 }

--- a/src/ui/toc.rs
+++ b/src/ui/toc.rs
@@ -64,7 +64,8 @@ pub fn add_table_of_contents(siv: &mut Cursive, toc: &TableOfContents) {
             toc_view
                 .with_name("toc_view")
                 .scrollable()
-                .scroll_x(true)
+                .scroll_x(config::CONFIG.settings.toc.scroll_x)
+                .scroll_y(config::CONFIG.settings.toc.scroll_y)
                 .full_height()
         )
         .title(toc.title())

--- a/src/wiki/article/parser.rs
+++ b/src/wiki/article/parser.rs
@@ -12,6 +12,7 @@ use select::{
     node::Node,
     predicate::{Attr, Class, Name},
 };
+use std::collections::HashMap;
 use std::io::Read;
 
 /// The Parser trait allows for generating an Article from a html source
@@ -105,18 +106,31 @@ impl DefaultParser {
             }
         }
 
+        // put number and text into a hashmap
+        let data = {
+            let mut data = HashMap::new();
+            data.insert("{NUMBER}", item_number);
+            data.insert("{TEXT}", item_text);
+            data
+        };
+
+        // format the text
+        let text = {
+            let mut text = CONFIG.settings.toc.item_format.to_string();
+            for (k, v) in &data {
+                text = text.replace(k, v);
+            }
+            text
+        };
+
         // return everything
-        Ok(TableOfContentsItem::new(
-            level,
-            format!("{} {}", item_number, item_text),
-            {
-                if sub_items.is_empty() {
-                    None
-                } else {
-                    Some(sub_items)
-                }
-            },
-        ))
+        Ok(TableOfContentsItem::new(level, text, {
+            if sub_items.is_empty() {
+                None
+            } else {
+                Some(sub_items)
+            }
+        }))
     }
 
     /// A helper function that parses a single node from a html document into one or multiple


### PR DESCRIPTION
This adds more configuration options for the table of contents. Currently these settings are added:
* `title` change the title of the toc 
* `min_width` adjust the minimum width
* `max_width` adjust the maximum width
* `scroll_x` horizontal scrolling
* `scroll_y` vertical scrolling
* `item_format` format for each toc item

Further usage can be found in the readme in the configuration section under `[settings.toc]`