### PR TITLE
Fix Word Spacing

### DIFF
--- a/src/ui/article/content.rs
+++ b/src/ui/article/content.rs
@@ -144,7 +144,12 @@ impl ArticleContent {
 
         self.link_handler = lines_wrapper.link_handler;
         self.rendered_lines = lines_wrapper.rendered_lines;
-        self.header_y_coords = lines_wrapper.header_y_coords;
+
+        if let Some(ref header_y) = lines_wrapper.header_y {
+            let mut header_y_coords = header_y.clone().into_values().collect::<Vec<usize>>();
+            header_y_coords.sort_unstable();
+            self.header_y_coords = Some(header_y_coords);
+        }
 
         log::debug!(
             "compute_lines finished successfully, rendering '{}' lines",

--- a/src/wiki/article/parser.rs
+++ b/src/wiki/article/parser.rs
@@ -418,6 +418,7 @@ mod tests {
                 "History".to_string(),
             )
             .attribute("type", "header")
+            .attribute("is_toc_header", "true")
         );
     }
 

--- a/src/wiki/article/parser.rs
+++ b/src/wiki/article/parser.rs
@@ -139,7 +139,7 @@ impl DefaultParser {
         match node.name().unwrap_or_default() {
             "h2" | "h3" | "h4" | "h5" => {
                 if let Some(headline_node) = node.find(Class("mw-headline")).next() {
-                    self.push_header(headline_node.text())
+                    self.push_header(headline_node.text(), true)
                 }
             }
             "b" => self.push_text(
@@ -253,19 +253,27 @@ impl DefaultParser {
     }
 
     /// A helper function that add a header to the elements. It constructs an ArticleElement from
-    /// a given content and adds it to the array
-    fn push_header(&mut self, content: String) {
+    /// a given content and adds it to the array. The parameter `is_toc_header` can be used to indicate
+    /// that the header is also located within the table of contents. Only toc headers can be jumped to
+    fn push_header(&mut self, content: String, is_toc_header: bool) {
         // we create a new article element with the correct style from the config and add a newline
         // afterwards
-        self.elements.push(
-            ArticleElement::new(
+        self.elements.push({
+            let mut element = ArticleElement::new(
                 self.get_id(),
                 content.chars().count(),
                 Style::from(CONFIG.theme.title).combine(Effect::Bold),
                 content,
             )
-            .attribute("type", "header"),
-        );
+            .attribute("type", "header")
+            .attribute("is_toc_header", "false");
+
+            if is_toc_header {
+                element.set_attribute("is_toc_header", "true");
+            }
+
+            element
+        });
         self.push_newline();
     }
 
@@ -310,7 +318,7 @@ impl Parser for DefaultParser {
         // retrieve the title of the article
         let title = self.get_title(&document)?;
         log::debug!("retrieved the title '{}' from the document", &title);
-        self.push_header(title);
+        self.push_header(title, false);
 
         // parse the article content
         document


### PR DESCRIPTION
This fixes many of the word spacing issues. These issues include but are not limited to:
* No whitespaces in between some words (especially between links and normal words)
* Incorrect leading or trailing whitespaces
* Special characters (`.`, `,`, `:`, `;`) not having the correct spacing