### PR TITLE
Fix the crash that occurs when no links or headers exist

### DIFF
--- a/src/ui/article/content.rs
+++ b/src/ui/article/content.rs
@@ -50,7 +50,7 @@ impl ArticleContent {
     /// Returns the id of the current link
     pub fn current_link(&self) -> Option<i32> {
         if let Some(ref link_handler) = self.link_handler {
-            return Some(link_handler.get_current_link());
+            return link_handler.get_current_link();
         }
         None
     }
@@ -65,7 +65,7 @@ impl ArticleContent {
     /// Returns the position of the current link
     pub fn current_link_pos(&self) -> Option<Vec2> {
         if let Some(ref link_handler) = self.link_handler {
-            return Some(link_handler.get_current_link_pos());
+            return link_handler.get_current_link_pos();
         }
         None
     }
@@ -73,7 +73,10 @@ impl ArticleContent {
     /// Returns the y-position of a given header
     pub fn header_y_pos(&self, index: usize) -> Option<usize> {
         if let Some(ref header_y_coords) = self.header_y_coords {
-            assert!(header_y_coords.len() > index);
+            if header_y_coords.len() <= index {
+                log::warn!("couldn't retrieve the header y-position, headers_len: '{}' <= header_index '{}'", header_y_coords.len(), index);
+                return None;
+            }
             return Some(header_y_coords[index]);
         }
         None

--- a/src/ui/article/links.rs
+++ b/src/ui/article/links.rs
@@ -31,22 +31,29 @@ impl LinkHandler {
         self.links.push(Link { id, x, y })
     }
 
-    /// Retrieves the id of the currently selected link
-    pub fn get_current_link(&self) -> i32 {
-        assert!(self.links.len() > self.current_link);
-        self.links[self.current_link].id
+    /// Retrieves the id of the currently selected link. If there are no links, None will be returned
+    pub fn get_current_link(&self) -> Option<i32> {
+        if self.links.is_empty() {
+            return None;
+        }
+        Some(self.links[self.current_link].id)
     }
 
-    /// Returns the position of the currently selected link
-    pub fn get_current_link_pos(&self) -> Vec2 {
-        assert!(self.links.len() > self.current_link);
+    /// Returns the position of the currently selected link. If there are no links, None will be returned
+    pub fn get_current_link_pos(&self) -> Option<Vec2> {
+        if self.links.is_empty() {
+            return None;
+        }
         let link = &self.links[self.current_link];
-        Vec2::new(link.x, link.y)
+        Some(Vec2::new(link.x, link.y))
     }
 
     /// Moves the selection up by a given amount
     pub fn move_up(&mut self, amount: usize) {
-        assert!(self.links.len() > self.current_link);
+        if self.links.is_empty() {
+            log::warn!("no links are registered, aborting...");
+            return;
+        }
 
         // save the minimum y-position
         let min_y = self.links[self.current_link].y.saturating_sub(amount);
@@ -66,6 +73,11 @@ impl LinkHandler {
 
     /// Moves the selection down by a given amount
     pub fn move_down(&mut self, amount: usize) {
+        if self.links.is_empty() {
+            log::warn!("no links are registered, aborting...");
+            return;
+        }
+
         // save the minimum y-position
         let min_y = self.links[self.current_link].y.saturating_add(amount);
 
@@ -84,11 +96,21 @@ impl LinkHandler {
 
     /// Moves the selection left by a given amount
     pub fn move_left(&mut self, amount: usize) {
+        if self.links.is_empty() {
+            log::warn!("no links are registered, aborting...");
+            return;
+        }
+
         self.current_link = self.current_link.saturating_sub(amount);
     }
 
     /// Moves the selection right by a given amount
     pub fn move_right(&mut self, amount: usize) {
+        if self.links.is_empty() {
+            log::warn!("no links are registered, aborting...");
+            return;
+        }
+
         // if we don't have enough links on the right, just select the last one
         if self.current_link + amount >= self.links.len() {
             self.current_link = self.links.len().saturating_sub(1);
@@ -100,6 +122,11 @@ impl LinkHandler {
 
     /// Overrides the current link
     pub fn set_current_link(&mut self, id: i32) {
+        if self.links.is_empty() {
+            log::warn!("no links are registered, aborting...");
+            return;
+        }
+
         let new_selection = self
             .links
             .iter()


### PR DESCRIPTION
This fixes a crash that occurs when no headers or links are present in an article. With this patch, when you want to select a header but none are present it will jump to the first line and print out a warning in the logfile.