### PR TITLE
Add label to exclude PRs from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,8 @@ changelog:
   exclude:
     authors:
       - allcontributors
+    labels:
+      - ignore-release
   categories:
     - title: Breaking Changes 🛠
       labels:


### PR DESCRIPTION
This PR adds the label "ignore-release". When a PR has this release, it will be excluded from the generated release notes. This is useful for small changes that aren't important for a release (for example a reformat or restructure of the codebase)
