### PR TITLE
Fix no article being displayed

### DIFF
--- a/src/ui/article/view.rs
+++ b/src/ui/article/view.rs
@@ -193,7 +193,10 @@ impl View for ArticleView {
                 self.content.move_selected_link(Absolute::Left, 1);
                 // if the current link is outside of the viewport, then scroll
                 // get the current links position
-                let current_link_pos = self.content.current_link_pos().unwrap_or_else(|| (0, 0).into());
+                let current_link_pos = self
+                    .content
+                    .current_link_pos()
+                    .unwrap_or_else(|| (0, 0).into());
 
                 // we've moved the link to the left, so we only need to check if the link is above
                 // the viewport
@@ -212,7 +215,10 @@ impl View for ArticleView {
                 self.content.move_selected_link(Absolute::Right, 1);
                 // if the current link is outside of the viewport, then scroll
                 // get the current links position
-                let current_link_pos = self.content.current_link_pos().unwrap_or_else(|| (0, 0).into());
+                let current_link_pos = self
+                    .content
+                    .current_link_pos()
+                    .unwrap_or_else(|| (0, 0).into());
 
                 // we've moved the link to the right, so we only need to check if the link is below
                 // the viewport

--- a/src/wiki/article/parser.rs
+++ b/src/wiki/article/parser.rs
@@ -321,13 +321,35 @@ impl Parser for DefaultParser {
         self.push_header(title, false);
 
         // parse the article content
-        document
+        let parsed_count = document
+            .find(Attr("id", "content"))
+            .into_selection()
+            .first()
+            .context("Couldn't find the node 'content'")?
+            .find(Attr("id", "bodyContent"))
+            .into_selection()
+            .first()
+            .context("Couldn't find the node 'bodyContent")?
+            .find(Attr("id", "mw-content-text"))
+            .into_selection()
+            .first()
+            .context("Couldn't find the node 'mw-content-text'")?
             .find(Class("mw-parser-output"))
-            .next()
-            .context("Couldn't find the content of the article")?
+            .into_selection()
+            .first()
+            .context("Couldn't find the node 'mw-parser-output'")?
             .children()
-            .map(|child| self.parse_node(child))
+            .map(|child| {
+                log::debug!("parsing the node {:?}", child);
+                self.parse_node(child)
+            })
             .count();
+
+        log::debug!(
+            "parsed '{}' nodes into '{}' elements",
+            &parsed_count,
+            self.elements.len()
+        );
 
         // parse the table of contents (if it exists)
         let mut toc = None;


### PR DESCRIPTION
This fixes a bug in the parser that caused no article to be displayed. 

The problem here was that we just looked for the HTML element that contained the whole article (it has the class "mw-parser-output") without taking into consideration that there can be multiple elements with that class. 

That means that if an article has another element with the same class but before the element containing the article, the bug happens. An example for this is the article '[Apple](https://en.wikipedia.org/wiki/Apple)'. As you can see in the picture below, it contains another element with the class "mw-parser-output" before the actual element.

![image](https://user-images.githubusercontent.com/37375448/183132602-474fdb77-369a-4501-a807-de39a65f9b7f.png)