### PR TITLE
Change config usage

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,7 @@ pub struct Settings {
     pub toc: TocSettings,
 }
 
+#[derive(Clone)]
 pub struct TocSettings {
     pub position: TocPosition,
     pub title: TocTitle,
@@ -128,11 +129,13 @@ pub struct TocSettings {
     pub item_format: String,
 }
 
+#[derive(Clone)]
 pub enum TocPosition {
     LEFT,
     RIGHT,
 }
 
+#[derive(Clone)]
 pub enum TocTitle {
     DEFAULT,
     CUSTOM,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use panic_message::panic_info_message;
 use std::collections::HashMap;
 use std::env;
+use std::fmt::Write;
 use std::panic::{set_hook, PanicInfo};
 use uuid::Uuid;
 
@@ -63,27 +64,30 @@ where
             "Unknown"
         };
 
-        payload.push_str(&format!("Name: {}\n", env!("CARGO_PKG_NAME")));
-        payload.push_str(&format!("Version: {}\n", env!("CARGO_PKG_VERSION")));
-        payload.push_str(&format!("Operating System: {}\n", os));
+        let _ = writeln!(payload, "Name: {}", env!("CARGO_PKG_NAME"));
+        let _ = writeln!(payload, "Version: {}", env!("CARGO_PKG_VERSION"));
+        let _ = writeln!(payload, "Operating System: {}", os);
 
-        payload.push_str(&format!("Cause: {}.\n", panic_info_message(info)));
+        let _ = writeln!(payload, "Cause: {}", panic_info_message(info));
 
         match info.location() {
-            Some(location) => payload.push_str(&format!(
-                "Panic occurred in file '{}' at line {}\n",
-                location.file(),
-                location.line()
-            )),
+            Some(location) => {
+                let _ = writeln!(
+                    payload,
+                    "Panic occurred in file '{}' at line {}",
+                    location.file(),
+                    location.line()
+                );
+            }
             None => payload.push_str("Panic location unknown.\n"),
-        }
+        };
 
         let logs = match std::fs::read_to_string(&CONFIG.logging.log_dir) {
             Ok(logs) => logs,
             Err(_) => "No logs available.".to_string(),
         };
 
-        payload.push_str(&format!("\n\nLogs: \n{}", logs));
+        let _ = write!(payload, "\n\nLogs: \n{}", logs);
 
         f(Some(path), payload);
     }))

--- a/src/ui/article/mod.rs
+++ b/src/ui/article/mod.rs
@@ -1,9 +1,6 @@
 use crate::ui::utils::remove_view_from_layout;
 use crate::wiki::{
-    article::{
-        parser::{DefaultParser, Parser},
-        Article, ArticleBuilder,
-    },
+    article::{parser::DefaultParser, Article, ArticleBuilder},
     search::SearchResult,
 };
 use crate::{
@@ -34,8 +31,12 @@ pub fn on_article_submit(siv: &mut Cursive, search_result: &SearchResult) {
         search_result.title(),
         search_result.page_id()
     );
-    let article = match ArticleBuilder::new(*search_result.page_id(), None)
-        .build(&mut DefaultParser::new())
+    let article = match ArticleBuilder::new(
+        *search_result.page_id(),
+        None,
+        &CONFIG.api_config.base_url,
+    )
+    .build(&mut DefaultParser::new(&CONFIG.settings.toc))
     {
         Ok(article) => article,
         Err(error) => {
@@ -126,7 +127,9 @@ fn open_link(siv: &mut Cursive, target: String) {
 
     // fetch the article
     log::debug!("fetching the article");
-    let article = match ArticleBuilder::new(0, Some(target)).build(&mut DefaultParser::new()) {
+    let article = match ArticleBuilder::new(0, Some(target), &CONFIG.api_config.base_url)
+        .build(&mut DefaultParser::new(&CONFIG.settings.toc))
+    {
         Ok(article) => article,
         Err(error) => {
             log::warn!("{:?}", error);

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -12,7 +12,7 @@ use cursive::{align::HAlign, utils::markup::StyledString, Cursive};
 
 /// Returns the default SearchBuilder
 fn build_search() -> SearchBuilder {
-    SearchBuilder::new()
+    SearchBuilder::new(&config::CONFIG.api_config.base_url)
         .info(SearchMetadata::new().total_hits())
         .prop(SearchProperties::new().snippet())
         .sort(SearchSortOrder::JustMatch)


### PR DESCRIPTION
This changes how the configuration is used in structs. Instead of getting them directly via the global variable, the config is passed to the struct as an argument.

Because of this, we can now test each struct better because we can directly manipulate the configuration for it.