### PR TITLE
Fix unexpected argument error when running tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Default)]
 pub struct Cli {
     /// Search for an article at startup with the given query
     pub search_query: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use lazy_static::*;
 use log::LevelFilter;
 use serde::Deserialize;
 use std::{path::PathBuf, str::FromStr};
+#[cfg(not(test))]
 use structopt::StructOpt;
 use toml::from_str;
 
@@ -291,7 +292,11 @@ impl Config {
                 },
             },
             config_path: PathBuf::new(),
+            #[cfg(not(test))]
             args: Cli::from_args(),
+
+            #[cfg(test)]
+            args: Cli::default(),
         };
 
         // load the configuration from the file


### PR DESCRIPTION
This fixes the unexpected argument error that appears when running the tests. It fixes this by removing the CLI argument parsing