### PR TITLE
Add focus keybindings to the config

### DIFF
--- a/docs/configuration/keybindings.md
+++ b/docs/configuration/keybindings.md
@@ -10,7 +10,7 @@ The key setting can be a simple character or a non-character key
 These are the supported non-character keys (lower-/uppercase doesn't matter);
 
 | Key              | Config Name    |
-| ---------------- | -------------- |
+|------------------|----------------|
 | ++insert++       | `insert`       |
 | ++delete++       | `delete`       |
 | ++home++         | `home`         |
@@ -23,14 +23,28 @@ These are the supported non-character keys (lower-/uppercase doesn't matter);
 
 ### Mode
 
+The following modes are supported
+
+| Key            | Config Name |
+|----------------|-------------|
+ |                | `normal`    |
+| ++shift++      | `shit`      |
+| ++alt++        | `alt`       |
+| ++alt+shift++  | `altshift`  |
+| ++ctrl++       | `ctrl`      |
+| ++ctrl+shift++ | `ctrlshift` |
+| ++ctrl+alt++   | `ctrlalt`   |
+
 ## Supported Actions
 
-| Action | Default Keybinding | Changeable Since                         |
-| ------ | ------------------ | ---------------------------------------- |
-| Down   | ++down++           | [:octicons-tag-24: 0.5.0][release-0.5.0] |
-| Up     | ++up++             | [:octicons-tag-24: 0.5.0][release-0.5.0] |
-| Left   | ++left++           | [:octicons-tag-24: 0.5.0][release-0.5.0] |
-| Right  | ++right++          | [:octicons-tag-24: 0.5.0][release-0.5.0] |
+| Action                  | Config Name  | Default Keybinding | Changeable Since                          |
+|-------------------------|--------------|--------------------|-------------------------------------------|
+| Scroll Down             | `down`       | ++down++           | [:octicons-tag-24: 0.5.0][release-0.5.0]  |
+| Scroll Up               | `up`         | ++up++             | [:octicons-tag-24: 0.5.0][release-0.5.0]  |
+| Scroll / Select Left    | `left`       | ++left++           | [:octicons-tag-24: 0.5.0][release-0.5.0]  |
+| Scroll / Select Right   | `right`      | ++right++          | [:octicons-tag-24: 0.5.0][release-0.5.0]  |
+| Focus the next view     | `focus_next` | ++tab++            | :fontawesome-solid-microchip: pre-release |
+| Focus the previous view | `focus_prev` | ++shift+tab++      | :fontawesome-solid-microchip: pre-release |
 
 ## Sample Remap
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,9 @@ pub struct Keybindings {
     pub up: Event,
     pub left: Event,
     pub right: Event,
+
+    pub focus_next: Event,
+    pub focus_prev: Event,
 }
 
 pub struct Settings {
@@ -234,6 +237,9 @@ struct UserKeybindings {
     up: Option<UserKeybinding>,
     left: Option<UserKeybinding>,
     right: Option<UserKeybinding>,
+
+    focus_next: Option<UserKeybinding>,
+    focus_prev: Option<UserKeybinding>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -279,6 +285,9 @@ impl Config {
                 up: Event::Key(Key::Up),
                 left: Event::Key(Key::Left),
                 right: Event::Key(Key::Right),
+
+                focus_next: Event::Key(Key::Tab),
+                focus_prev: Event::Shift(Key::Tab),
             },
             settings: Settings {
                 toc: TocSettings {
@@ -619,6 +628,32 @@ impl Config {
             ) {
                 Ok(event_key) => {
                     self.keybindings.right = event_key;
+                }
+                Err(error) => {
+                    log::warn!("{:?}", error)
+                }
+            }
+        }
+        if let Some(keybinding) = &user_keybindings.focus_next {
+            match parse_keybinding(
+                &keybinding.key,
+                keybinding.mode.as_ref().unwrap_or(&"normal".to_string()),
+            ) {
+                Ok(event_key) => {
+                    self.keybindings.focus_next = event_key;
+                }
+                Err(error) => {
+                    log::warn!("{:?}", error)
+                }
+            }
+        }
+        if let Some(keybinding) = &user_keybindings.focus_prev {
+            match parse_keybinding(
+                &keybinding.key,
+                keybinding.mode.as_ref().unwrap_or(&"normal".to_string()),
+            ) {
+                Ok(event_key) => {
+                    self.keybindings.focus_prev = event_key;
                 }
                 Err(error) => {
                     log::warn!("{:?}", error)

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,11 +107,12 @@ pub struct Features {
     pub toc: bool,
 }
 
+#[derive(Clone)]
 pub struct Keybindings {
-    pub down: Option<Event>,
-    pub up: Option<Event>,
-    pub left: Option<Event>,
-    pub right: Option<Event>,
+    pub down: Event,
+    pub up: Event,
+    pub left: Event,
+    pub right: Event,
 }
 
 pub struct Settings {
@@ -274,10 +275,10 @@ impl Config {
                 toc: true,
             },
             keybindings: Keybindings {
-                down: None,
-                up: None,
-                left: None,
-                right: None,
+                down: Event::Key(Key::Down),
+                up: Event::Key(Key::Up),
+                left: Event::Key(Key::Left),
+                right: Event::Key(Key::Right),
             },
             settings: Settings {
                 toc: TocSettings {
@@ -578,7 +579,7 @@ impl Config {
                 keybinding.mode.as_ref().unwrap_or(&"normal".to_string()),
             ) {
                 Ok(event_key) => {
-                    self.keybindings.down = Some(event_key);
+                    self.keybindings.down = event_key;
                 }
                 Err(error) => {
                     log::warn!("{:?}", error)
@@ -591,7 +592,7 @@ impl Config {
                 keybinding.mode.as_ref().unwrap_or(&"normal".to_string()),
             ) {
                 Ok(event_key) => {
-                    self.keybindings.up = Some(event_key);
+                    self.keybindings.up = event_key;
                 }
                 Err(error) => {
                     log::warn!("{:?}", error)
@@ -604,7 +605,7 @@ impl Config {
                 keybinding.mode.as_ref().unwrap_or(&"normal".to_string()),
             ) {
                 Ok(event_key) => {
-                    self.keybindings.left = Some(event_key);
+                    self.keybindings.left = event_key;
                 }
                 Err(error) => {
                     log::warn!("{:?}", error)
@@ -617,7 +618,7 @@ impl Config {
                 keybinding.mode.as_ref().unwrap_or(&"normal".to_string()),
             ) {
                 Ok(event_key) => {
-                    self.keybindings.right = Some(event_key);
+                    self.keybindings.right = event_key;
                 }
                 Err(error) => {
                     log::warn!("{:?}", error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,13 @@ extern crate anyhow;
 extern crate lazy_static;
 extern crate log;
 
+#[macro_use]
+extern crate cursive;
+
+use crate::config::CONFIG;
 use cursive::align::HAlign;
 use cursive::backends;
+use cursive::direction::Orientation;
 use cursive::theme::*;
 use cursive::traits::*;
 use cursive::view::Resizable;
@@ -13,6 +18,7 @@ use cursive_buffered_backend::BufferedBackend;
 use std::fs;
 use std::io::Write;
 
+use crate::ui::RootLayout;
 use crate::wiki::search::SearchResult;
 
 pub mod cli;
@@ -125,9 +131,9 @@ fn start_application() {
         .with_name("logo_view")
         .full_screen();
 
-    let article_layout = override_keybindings!(LinearLayout::horizontal()
+    let article_layout = RootLayout::new(Orientation::Horizontal, CONFIG.keybindings.clone())
         .child(Dialog::around(logo_view))
-        .with_name("article_layout"));
+        .with_name("article_layout");
 
     // Add a fullscreen layer, containing the search bar and the article view
     siv.add_fullscreen_layer(

--- a/src/ui/article/mod.rs
+++ b/src/ui/article/mod.rs
@@ -5,13 +5,14 @@ use crate::wiki::{
 };
 use crate::{
     config::{self, TocPosition, CONFIG},
-    ui, view_with_theme,
+    ui::{self, RootLayout},
+    view_with_theme,
 };
 
 use anyhow::{bail, Context, Result};
 use cursive::align::HAlign;
 use cursive::view::{Nameable, Scrollable};
-use cursive::views::{Dialog, LinearLayout, TextView};
+use cursive::views::{Dialog, TextView};
 use cursive::Cursive;
 
 mod content;
@@ -204,7 +205,7 @@ fn display_article(siv: &mut Cursive, article: Article) -> Result<()> {
     };
 
     // add the article view to the screen
-    let result = siv.call_on_name("article_layout", |view: &mut LinearLayout| {
+    let result = siv.call_on_name("article_layout", |view: &mut RootLayout| {
         if CONFIG.features.toc && has_toc {
             view.insert_child(
                 index,

--- a/src/ui/article/mod.rs
+++ b/src/ui/article/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 
 use anyhow::{bail, Context, Result};
 use cursive::align::HAlign;
+use cursive::direction::Orientation;
 use cursive::view::{Nameable, Scrollable};
 use cursive::views::{Dialog, TextView};
 use cursive::Cursive;
@@ -99,21 +100,23 @@ pub fn on_link_submit(siv: &mut Cursive, target: String) {
     siv.add_layer(
         // create a dialog that asks the user for confirmation whether he really wants to open this
         // link
-        Dialog::around(TextView::new(format!(
-            "Do you want to open the article '{}'?",
-            target_human
-        )))
-        .button("Yep", move |s| {
-            log::info!("on_link_submit - user said yes :) continuing...");
-            // the human wants us to open the link for him... we will comply...
-            open_link(s, target.clone())
-        })
-        .button("Nope", move |s| {
-            log::info!("on_link_submit - said no :/ aborting...");
-            // so he doesn't want us to open the link... delete the whole dialog and pretend it
-            // didn't happen
-            s.pop_layer();
-        }),
+        RootLayout::new(Orientation::Vertical, CONFIG.keybindings.clone()).child(
+            Dialog::around(TextView::new(format!(
+                "Do you want to open the article '{}'?",
+                target_human
+            )))
+            .button("Yep", move |s| {
+                log::info!("on_link_submit - user said yes :) continuing...");
+                // the human wants us to open the link for him... we will comply...
+                open_link(s, target.clone())
+            })
+            .button("Nope", move |s| {
+                log::info!("on_link_submit - said no :/ aborting...");
+                // so he doesn't want us to open the link... delete the whole dialog and pretend it
+                // didn't happen
+                s.pop_layer();
+            }),
+        ),
     );
 
     log::info!("on_link_submit finished successfully");

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,8 +1,10 @@
 pub mod article;
 pub mod models;
+mod root;
 pub mod search;
 mod theme_view;
 pub mod toc;
 pub mod utils;
 
 pub type ThemedView<T> = theme_view::ThemedView<T>;
+pub type RootLayout = root::RootLayout;

--- a/src/ui/root.rs
+++ b/src/ui/root.rs
@@ -1,0 +1,62 @@
+use crate::config::Keybindings;
+use cursive::direction::Orientation;
+use cursive::event::{Event, EventResult, Key};
+use cursive::view::{IntoBoxedView, View, ViewWrapper};
+use cursive::views::LinearLayout;
+use cursive::Vec2;
+
+pub struct RootLayout {
+    layout: LinearLayout,
+    keybindings: Keybindings,
+}
+
+impl RootLayout {
+    pub fn new(orientation: Orientation, keybindings: Keybindings) -> Self {
+        RootLayout {
+            layout: LinearLayout::new(orientation),
+            keybindings,
+        }
+    }
+
+    pub fn child<V: IntoBoxedView + 'static>(mut self, view: V) -> Self {
+        self.add_child(view);
+        self
+    }
+
+    pub fn insert_child<V: IntoBoxedView + 'static>(&mut self, i: usize, view: V) {
+        self.layout.insert_child(i, view);
+    }
+
+    pub fn add_child<V: IntoBoxedView + 'static>(&mut self, view: V) {
+        self.layout.add_child(view);
+    }
+
+    pub fn remove_child(&mut self, i: usize) -> Option<Box<dyn View>> {
+        self.layout.remove_child(i)
+    }
+
+    pub fn find_child_from_name(&mut self, name: &str) -> Option<usize> {
+        self.layout.find_child_from_name(name)
+    }
+}
+
+impl ViewWrapper for RootLayout {
+    wrap_impl!(self.layout: LinearLayout);
+
+    fn wrap_on_event(&mut self, ch: Event) -> EventResult {
+        match ch {
+            // movement
+            key if key == self.keybindings.up => self.layout.on_event(Event::Key(Key::Up)),
+            key if key == self.keybindings.down => self.layout.on_event(Event::Key(Key::Down)),
+            key if key == self.keybindings.left => self.layout.on_event(Event::Key(Key::Left)),
+            key if key == self.keybindings.right => self.layout.on_event(Event::Key(Key::Right)),
+
+            // focus
+            _ => self.layout.on_event(ch),
+        }
+    }
+
+    fn wrap_layout(&mut self, size: Vec2) {
+        self.layout.layout(size);
+    }
+}

--- a/src/ui/root.rs
+++ b/src/ui/root.rs
@@ -52,6 +52,11 @@ impl ViewWrapper for RootLayout {
             key if key == self.keybindings.right => self.layout.on_event(Event::Key(Key::Right)),
 
             // focus
+            key if key == self.keybindings.focus_next => self.layout.on_event(Event::Key(Key::Tab)),
+            key if key == self.keybindings.focus_prev => {
+                self.layout.on_event(Event::Shift(Key::Tab))
+            }
+
             _ => self.layout.on_event(ch),
         }
     }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -1,8 +1,11 @@
 use crate::{
-    config, override_keybindings, ui, view_with_theme,
+    config,
+    ui::{self, RootLayout},
+    view_with_theme,
     wiki::search::{
         SearchBuilder, SearchMetadata, SearchProperties, SearchResult, SearchSortOrder,
     },
+    Orientation, CONFIG,
 };
 
 use anyhow::{Context, Result};
@@ -99,22 +102,25 @@ pub fn on_search(siv: &mut Cursive, search_query: String) {
     }
 
     // create the search results layout
-    let search_results_layout = LinearLayout::horizontal()
-        .child(view_with_theme!(
-            config::CONFIG.theme.search_results,
-            Dialog::around(override_keybindings!(LinearLayout::vertical()
-                .child(
-                    search_results_view
-                        .with_name("search_results_view")
-                        .scrollable()
-                        .min_height(10)
+    let search_results_layout =
+        RootLayout::new(Orientation::Horizontal, CONFIG.keybindings.clone())
+            .child(view_with_theme!(
+                config::CONFIG.theme.search_results,
+                Dialog::around(
+                    LinearLayout::vertical()
+                        .child(
+                            search_results_view
+                                .with_name("search_results_view")
+                                .scrollable()
+                                .min_height(10)
+                        )
+                        .child(search_continue_button),
                 )
-                .child(search_continue_button)),)
-        ))
-        .child(view_with_theme!(
-            config::CONFIG.theme.search_preview,
-            Dialog::around(search_results_preview)
-        ));
+            ))
+            .child(view_with_theme!(
+                config::CONFIG.theme.search_preview,
+                Dialog::around(search_results_preview)
+            ));
     log::debug!("created the search results layout");
 
     // finally, add the whole thing as a new layer

--- a/src/ui/toc.rs
+++ b/src/ui/toc.rs
@@ -1,6 +1,5 @@
 use crate::config;
-use crate::ui;
-use crate::ui::article::ArticleView;
+use crate::ui::{self, article::ArticleView, RootLayout};
 use crate::view_with_theme;
 use crate::wiki::article::TableOfContents;
 use crate::wiki::article::TableOfContentsItem;
@@ -8,12 +7,15 @@ use crate::wiki::article::TableOfContentsItem;
 use cursive::event::{Event, Key};
 use cursive::traits::Scrollable;
 use cursive::view::{Nameable, Resizable};
-use cursive::views::{Dialog, LinearLayout, SelectView};
+use cursive::views::{Dialog, SelectView};
 use cursive::Cursive;
 
 pub fn add_table_of_contents(siv: &mut Cursive, toc: &TableOfContents) {
     // get the article_layout and create an empty select view
-    let mut article_layout = siv.find_name::<LinearLayout>("article_layout").unwrap();
+
+    // FIXME: report an error, if the layout could not be found or maybe add a Result<> return type
+    let mut article_layout = siv.find_name::<RootLayout>("article_layout").unwrap();
+
     let mut toc_view = SelectView::<TableOfContentsItem>::new().on_submit(|siv, item| {
         log::info!("jumping to '{}'", item.text());
         let item_index = match siv.find_name::<SelectView<TableOfContentsItem>>("toc_view") {

--- a/src/ui/toc.rs
+++ b/src/ui/toc.rs
@@ -13,9 +13,7 @@ use cursive::Cursive;
 pub fn add_table_of_contents(siv: &mut Cursive, toc: &TableOfContents) {
     // get the article_layout and create an empty select view
 
-    // FIXME: report an error, if the layout could not be found or maybe add a Result<> return type
     let mut article_layout = siv.find_name::<RootLayout>("article_layout").unwrap();
-
     let mut toc_view = SelectView::<TableOfContentsItem>::new().on_submit(|siv, item| {
         log::info!("jumping to '{}'", item.text());
         let item_index = match siv.find_name::<SelectView<TableOfContentsItem>>("toc_view") {

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,9 +1,10 @@
-use cursive::{views::LinearLayout, Cursive};
+use crate::ui::RootLayout;
+use cursive::Cursive;
 
 /// Removes a given view from a given layout. If the view or the layout couldn't be found, the
 /// function fails silently
 pub fn remove_view_from_layout(siv: &mut Cursive, view_name: &str, layout_name: &str) {
-    let result = siv.call_on_name(layout_name, |view: &mut LinearLayout| {
+    let result = siv.call_on_name(layout_name, |view: &mut RootLayout| {
         if let Some(i) = view.find_child_from_name(view_name) {
             log::debug!("removed '{}' from '{}'", view_name, layout_name);
             view.remove_child(i);
@@ -25,44 +26,4 @@ macro_rules! view_with_theme {
             ui::ThemedView::new(config::CONFIG.theme.to_theme(), $view)
         }
     };
-}
-
-/// Wraps a view into a OnEventView that overrides the keybindings of the view with the ones
-/// defined in the config
-#[macro_export]
-macro_rules! override_keybindings {
-    ($view: expr) => {{
-        let mut event_view = cursive::views::OnEventView::new($view);
-
-        // go through all of the keybindings
-        if let Some(event_key) = config::CONFIG.keybindings.down.clone() {
-            log::debug!("registered the '{:?}' key as Down", event_key);
-            event_view.set_on_pre_event(event_key, |siv: &mut cursive::Cursive| {
-                siv.on_event(cursive::event::Event::Key(cursive::event::Key::Down))
-            });
-        }
-
-        if let Some(event_key) = config::CONFIG.keybindings.up.clone() {
-            log::debug!("registered the '{:?}' key as Up", event_key);
-            event_view.set_on_pre_event(event_key, |siv: &mut cursive::Cursive| {
-                siv.on_event(cursive::event::Event::Key(cursive::event::Key::Up))
-            });
-        }
-
-        if let Some(event_key) = config::CONFIG.keybindings.left.clone() {
-            log::debug!("registered the '{:?}' key as Left", event_key);
-            event_view.set_on_pre_event(event_key, |siv: &mut cursive::Cursive| {
-                siv.on_event(cursive::event::Event::Key(cursive::event::Key::Left))
-            });
-        }
-
-        if let Some(event_key) = config::CONFIG.keybindings.right.clone() {
-            log::debug!("registered the '{:?}' key as Right", event_key);
-            event_view.set_on_pre_event(event_key, |siv: &mut cursive::Cursive| {
-                siv.on_event(cursive::event::Event::Key(cursive::event::Key::Right))
-            });
-        }
-
-        event_view
-    }};
 }


### PR DESCRIPTION
This PR adds the option to change the keybindings for the focus selection. It introduces two new configuration values. These are `keybindings.focus_next` and `keybindings.focus_prev`. The defaults and a sample usage configuration are below:

```toml
[keybindings]
focus_next.key = "n"
focus_prev.key = "p"
```
> An example of how to use these new settings

```toml
[keybindings]
focus_next.key = "tab"
focus_prev.key = "tab"
focus_prev.mode = "shift"
```
> The default configuration