### PR TITLE
Update default labels in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
-labels: bug
+labels: "type: bug"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: "[FEATURE]"
-labels: enhancement
+labels: "type: feature"
 assignees: ''
 
 ---


### PR DESCRIPTION
| Linked Issues |  #124  |
|---------------|---|

This updates the default labels in the issue templates (`bug-report` and `feature-request`). The change was necessary because of the issue label changes.