### PR TITLE
Add keywords to the cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["builditluc <37375448+Builditluc@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/Builditluc/wiki-tui"
 description = "A simple and easy to use Wikipedia Text User Interface"
+keywords = ["tui", "wikipedia"]
 license = "MIT"
 readme = "README.md"
 


### PR DESCRIPTION
Changes made:
* chore: add 'tui' keyword to the cargo manifest
* chore: add 'wikipedia' keyword to the cargo manifest