### PR TITLE
Fix whitespace at the top of some articles

### DIFF
--- a/src/wiki/parser.rs
+++ b/src/wiki/parser.rs
@@ -120,6 +120,9 @@ impl Parser {
     }
 
     fn parse_paragraph(&mut self, node: Node) {
+        if let Some("mw-empty-elt") = node.attr("class") {
+            return;
+        }
         self.parse_text(node);
         self.push_newline();
         self.push_newline();


### PR DESCRIPTION
| Linked to | #114 |
|---|---|

Changes made:
* fix: ignore 'mw-empty-elt' paragraphs
