### PR TITLE
Vim movements (ctrl+d, ctrl+u, gg, G)

### DIFF
--- a/docs/configuration/keybindings.md
+++ b/docs/configuration/keybindings.md
@@ -45,6 +45,11 @@ The following modes are supported
 | Scroll / Select Right   | `right`      | ++right++          |
 | Focus the next view     | `focus_next` | ++tab++            |
 | Focus the previous view | `focus_prev` | ++shift+tab++      |
+| Go to Top               | N/a          | ++gg++             |
+| Go to Bottom            | N/a          | ++G++              |
+| Half page down          | N/a          | ++ctrl+d++         |
+| Half page up            | N/a          | ++ctrl+u++         |
+| Focus the previous view | `focus_prev` | ++shift+tab++      |
 | Toggle the language selection | `toggle_language_selection` | ++f2++ |
 
 > When updating the language via the selection popup, existing search results and links in articles

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Cli {
     pub level: Option<i32>,
 
     #[structopt(short = "l", long = "language")]
-    /// Override the configured language of wikipeida. The value can be either the language code or
+    /// Override the configured language of wikipedia. The value can be either the language code or
     /// the name of the language in english or the name in its local language
     pub language: Option<String>,
 

--- a/src/ui/scroll.rs
+++ b/src/ui/scroll.rs
@@ -1,10 +1,9 @@
-use std::time::{Duration, SystemTime};
-
 use cursive::{
     event::{Event, EventResult, Key, MouseButton, MouseEvent},
     Rect, Vec2,
 };
 use std::cell::RefCell;
+use std::time::{Duration, SystemTime};
 
 const SCROLL_STRATEGY: ScrollStrategy = ScrollStrategy::KeepRow;
 const SCROLL_WHEEL_DOWN: usize = 3;

--- a/src/ui/scroll.rs
+++ b/src/ui/scroll.rs
@@ -82,7 +82,6 @@ where
                     scroller.get_scroller_mut().scroll_down(SCROLL_PAGE_DOWN)
                 }
                 Event::Char('G') => scroller.get_scroller_mut().scroll_to_bottom(),
-                // TODO(enoumy): Make this be gg in short sequence.
                 Event::Char('g') => {
                     let now = SystemTime::now();
                     LAST_TIME_G_WAS_PRESSED.with(|last_time| {

--- a/src/ui/scroll.rs
+++ b/src/ui/scroll.rs
@@ -76,6 +76,10 @@ where
                 Event::Key(Key::PageDown) if scroller.get_scroller_mut().can_scroll_down() => {
                     scroller.get_scroller_mut().scroll_down(SCROLL_PAGE_DOWN)
                 }
+                Event::Char('G') => scroller.get_scroller_mut().scroll_to_bottom(),
+                // TODO(enoumy): Make this be gg in short sequence.
+                Event::Char('g') => scroller.get_scroller_mut().scroll_to_top(),
+
                 Event::CtrlChar('d') => {
                     if scroller.get_scroller_mut().can_scroll_down() {
                         scroller

--- a/src/ui/scroll.rs
+++ b/src/ui/scroll.rs
@@ -57,6 +57,8 @@ where
         EventResult::Ignored
     };
 
+    let half_viewport_height = scroller.get_scroller().content_viewport().height() / 2;
+
     match result {
         EventResult::Ignored => {
             match event {
@@ -73,6 +75,18 @@ where
                 }
                 Event::Key(Key::PageDown) if scroller.get_scroller_mut().can_scroll_down() => {
                     scroller.get_scroller_mut().scroll_down(SCROLL_PAGE_DOWN)
+                }
+                Event::CtrlChar('d') => {
+                    if scroller.get_scroller_mut().can_scroll_down() {
+                        scroller
+                            .get_scroller_mut()
+                            .scroll_down(half_viewport_height)
+                    }
+                }
+                Event::CtrlChar('u') => {
+                    if scroller.get_scroller_mut().can_scroll_up() {
+                        scroller.get_scroller_mut().scroll_up(half_viewport_height)
+                    }
                 }
                 key if key == CONFIG.keybindings.down
                     && scroller.get_scroller_mut().can_scroll_down() =>

--- a/src/ui/scroll.rs
+++ b/src/ui/scroll.rs
@@ -1,13 +1,18 @@
+use std::time::{Duration, SystemTime};
+
 use cursive::{
     event::{Event, EventResult, Key, MouseButton, MouseEvent},
     Rect, Vec2,
 };
+use std::cell::RefCell;
 
 const SCROLL_STRATEGY: ScrollStrategy = ScrollStrategy::KeepRow;
 const SCROLL_WHEEL_DOWN: usize = 3;
 const SCROLL_WHEEL_UP: usize = 3;
 const SCROLL_PAGE_UP: usize = 10;
 const SCROLL_PAGE_DOWN: usize = 10;
+
+thread_local!(static LAST_TIME_G_WAS_PRESSED : RefCell<Option<SystemTime>> = RefCell::new(None));
 
 pub use cursive::view::scroll::{draw, layout, required_size, Core, ScrollStrategy, Scroller};
 
@@ -78,7 +83,20 @@ where
                 }
                 Event::Char('G') => scroller.get_scroller_mut().scroll_to_bottom(),
                 // TODO(enoumy): Make this be gg in short sequence.
-                Event::Char('g') => scroller.get_scroller_mut().scroll_to_top(),
+                Event::Char('g') => {
+                    let now = SystemTime::now();
+                    LAST_TIME_G_WAS_PRESSED.with(|last_time| {
+                        if let Some(last_time) = *last_time.borrow() {
+                            if let Ok(duration) = now.duration_since(last_time) {
+                                if duration < Duration::from_millis(300) {
+                                    scroller.get_scroller_mut().scroll_to_top()
+                                }
+                            }
+                        }
+                    });
+
+                    LAST_TIME_G_WAS_PRESSED.with(|last_time| *last_time.borrow_mut() = Some(now))
+                }
 
                 Event::CtrlChar('d') => {
                     if scroller.get_scroller_mut().can_scroll_down() {


### PR DESCRIPTION
This pull request is meant to address _some_, but not _all_ of the vim movements requested in #161 .

This pull request _adds_ the following vim movements:
* `ctrl+d`: moves half buffer size down.
* `ctrl+u`: moved half buffer size up.
* `gg`: moves to `top` of buffer.
* `G`: moves to `bot` of buffer.

Testing
======
What is the testing story? I manually built the project and ran it and things seemed to work. Are there any tests I should also update?

Documentation
=============
Documented keybindings. Did not pick config names as I am unsure whether these should be configured? Should they given that they are vim-specific?

Thanks!
Enoumy

(This section below gets added to the changelog and the release)

## Release Notes

The Vim keybindings `ctrl+d`, `ctrl+u`, `gg`, and `G` have been implemented!