### PR TITLE
Correctly handle non-existent pages

### DIFF
--- a/src/ui/article/view.rs
+++ b/src/ui/article/view.rs
@@ -128,6 +128,18 @@ impl ArticleView {
                 })));
             }
 
+            // check whether the page exists
+            if element.attr("new_page").is_some() {
+                warn!("the page doesn't exist yet");
+                return EventResult::Consumed(Some(Callback::from_fn(move |s| {
+                    display_message(
+                        s,
+                        "Information",
+                        "This page cannot be opened because it doesn't exist yet",
+                    )
+                })));
+            }
+
             info!(
                 "opening the link '{}' with the target '{}'",
                 element.id(),

--- a/src/wiki/parser.rs
+++ b/src/wiki/parser.rs
@@ -205,6 +205,10 @@ impl<'a> Parser<'a> {
             attributes.insert("external".to_string(), String::new());
         }
 
+        if node.attr("class") == Some("new") {
+            attributes.insert("new_page".to_string(), String::new());
+        }
+
         attributes.insert("target".to_string(), target);
 
         self.elements.push(Element::new(


### PR DESCRIPTION
Changes made:
* detect empty page links
* display message for empty pages

Linked to #184 

## Release Notes

When you now try to open a link leading to a page that doesn't exist yet, a warning will now pop up informing you about the missing page.