### PR TITLE
Fix ghost lists from Portalbox

### DIFF
--- a/src/wiki/parser.rs
+++ b/src/wiki/parser.rs
@@ -75,6 +75,10 @@ impl<'a> Parser<'a> {
             "a" => self.parse_link(node),
             "b" => self.parse_effect(node, Effect::Bold),
             "i" => self.parse_effect(node, Effect::Italic),
+            "ul" if node
+                .attr("class")
+                .map(|x| x.contains("portalbox"))
+                .unwrap_or(false) => {}
             "ul" => self.parse_list(node),
             "div"
                 if node


### PR DESCRIPTION
This fixes ghost list items appearing because the unsupported portalbox lists
were being parsed (unsuccessfully)
