### PR TITLE
docs: remove AUR install option

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -22,10 +22,6 @@ nix-shell -p wiki-tui
 
 Or add it to your configuration.
 
-### AUR
-
-The package is available in the [AUR](https://aur.archlinux.org/packages/wiki-tui). Either install it with `makepkg` manually or use the preferred AUR helper.
-
 ### Void
 
 As root, run


### PR DESCRIPTION
The AUR package has been moved into the Arch `extra` repository.