### PR TITLE
docs: added x install Support for wiki-tui

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -62,6 +62,14 @@ cd /usr/ports/www/wiki-tui/
 make install clean
 ```
 
+### X-CMD
+
+If you are a user of [x-cmd](https://x-cmd.com), you can run:
+
+```sh
+x install wiki-tui
+```
+
 ### Cargo
 
 If wiki-tui cannot be installed with your package manager, you can also install it with cargo. There are no extra dependencies (except rust of course).


### PR DESCRIPTION
Hi there,

I've updated the installation.md to include x install from the x-cmd ecosystem, making wiki-tui installation easier across different platforms and package managers.

I've also created an introduction page:
👉 https://x-cmd.com/install/wiki-tui

Hope this helps! Let me know if any changes are needed.

Thanks!