### PR TITLE
Fix that popups don't consume all key events

### DIFF
--- a/src/components/message_popup.rs
+++ b/src/components/message_popup.rs
@@ -84,7 +84,7 @@ impl<'a> Component for MessagePopupComponent<'a> {
             KeyCode::Char('n') if self.confirmation.is_some() => Action::PopPopup.into(),
 
             KeyCode::Esc => Action::PopPopup.into(),
-            _ => ActionResult::Ignored,
+            _ => ActionResult::consumed(),
         }
     }
 

--- a/src/components/page_language_popup.rs
+++ b/src/components/page_language_popup.rs
@@ -113,7 +113,7 @@ impl Component for PageLanguageSelectionComponent {
                 self.update_list();
                 ActionResult::consumed()
             }
-            _ => ActionResult::Ignored,
+            _ => ActionResult::consumed(),
         }
     }
 

--- a/src/components/search_language_popup.rs
+++ b/src/components/search_language_popup.rs
@@ -108,7 +108,7 @@ impl Component for SearchLanguageSelectionComponent {
                 self.update_list();
                 ActionResult::consumed()
             }
-            _ => ActionResult::Ignored,
+            _ => ActionResult::consumed(),
         }
     }
 


### PR DESCRIPTION
So it feels more intuitive for users not to be able to interact with the background with the present of a popup. It also prevents multiple popups at the same time.