### PR TITLE
Fix message popups don't consume all key events

### DIFF
--- a/src/components/message_popup.rs
+++ b/src/components/message_popup.rs
@@ -84,7 +84,7 @@ impl<'a> Component for MessagePopupComponent<'a> {
             KeyCode::Char('n') if self.confirmation.is_some() => Action::PopPopup.into(),
 
             KeyCode::Esc => Action::PopPopup.into(),
-            _ => ActionResult::Ignored,
+            _ => ActionResult::consumed(),
         }
     }
 


### PR DESCRIPTION
So it's more intuitive for users not able to interact with the background when there's a message popup.