### PR TITLE
Fix nix-shell: move pkg-config to nativeBuildInputs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -11,10 +11,10 @@ pkgs.callPackage (
     nativeBuildInputs = [
       rustup
       rustPlatform.bindgenHook
+      pkgs.pkg-config
     ];
     buildInputs = with pkgs; [
       openssl
-      pkg-config
     ] ++ lib.optionals stdenv.isDarwin [
       darwin.apple_sdk.frameworks.Security
     ];


### PR DESCRIPTION
Cargo was throwing this error during build:

```
...
error: could not find system library 'openssl' required by the 'openssl-sys' crate

--- stderr
Package openssl was not found in the pkg-config search path.
Perhaps you should add the directory containing `openssl.pc'
to the PKG_CONFIG_PATH environment variable
Package 'openssl' not found

...

It looks like you're compiling on Linux and also targeting Linux. Currently this
requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
could not be found. If you have OpenSSL installed you can likely fix this by
installing `pkg-config`.
...
```

I moved `pkg-config` from `buildInputs` to `nativeBuildInputs`, adding it to PATH.

That fixed the issue for me, but I don't understand why shell.nix was written that way.
@Builditluc, was pkg-config installed on your host system?
