### PR TITLE
feat: proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2010,6 +2011,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,11 @@ async fn main() -> Result<()> {
     initialize_logging(results.log_level)?;
     initialize_panic_handler()?;
 
+    // Log match cli message
+    for err in results.warn_list {
+        warn!(err)
+    }
+
     let (action_tx, mut action_rx) = mpsc::unbounded_channel();
 
     let app_component = Arc::new(Mutex::new(AppComponent::default()));

--- a/wiki-api/Cargo.toml
+++ b/wiki-api/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = { version = "2.6.0", features = ["serde"] }
 ego-tree = "0.6.2"
 html5ever = "0.26.0"
 markup5ever_rcdom = "0.2.0"
-reqwest = "0.11.20"
+reqwest = { version = "0.11.20", features = ["socks"] }
 scraper = "0.17.1"
 serde = "1.0.188"
 serde_json = "1.0.105"

--- a/wiki-api/src/lib.rs
+++ b/wiki-api/src/lib.rs
@@ -4,6 +4,7 @@ pub mod document;
 pub mod languages;
 pub mod page;
 pub mod parser;
+pub mod proxy;
 pub mod search;
 
 // TODO: Make Endpoint a real struct

--- a/wiki-api/src/proxy.rs
+++ b/wiki-api/src/proxy.rs
@@ -1,0 +1,34 @@
+use reqwest::Proxy;
+use std::sync::OnceLock;
+
+static PROXY: OnceLock<Proxy> = OnceLock::new();
+
+fn validate_proxy(addr: &str) -> Result<(), String> {
+    let _addr_clean = if let Some(addr) = addr.strip_prefix("socks5://") {
+        addr
+    } else if let Some(addr) = addr.strip_prefix("http://") {
+        addr
+    } else if let Some(addr) = addr.strip_prefix("https://") {
+        addr
+    } else {
+        return Err(format!("Invalid proxy protocol: {}", addr));
+    };
+
+    // TODO: check host and port
+    Ok(())
+}
+
+// Init proxy only once
+pub fn init_proxy(str: &str) -> Result<(), String> {
+    validate_proxy(str)?;
+    let proxy = match Proxy::all(str) {
+        Ok(o) => o,
+        Err(e) => return Err(e.to_string()),
+    };
+    PROXY.set(proxy).expect("init error");
+    Ok(())
+}
+
+pub fn get_proxy() -> Option<&'static Proxy> {
+    PROXY.get()
+}

--- a/wiki-api/src/search.rs
+++ b/wiki-api/src/search.rs
@@ -13,6 +13,7 @@ use std::fmt::Write;
 use crate::Endpoint;
 
 use crate::languages::Language;
+use crate::proxy::get_proxy;
 
 /// A finished search containing the found results and additional optional information regarding
 /// the search
@@ -699,7 +700,15 @@ impl SearchBuilder<WithQuery, WithEndpoint, WithLanguage> {
     /// - The returned result could not interpreted as a `Search`
     pub async fn search(self) -> Result<Search> {
         async fn action_query(params: Vec<(&str, String)>, endpoint: Endpoint) -> Result<Response> {
-            Client::new()
+            // Create builder with proxy
+            let client_builder = match get_proxy() {
+                Some(proxy) => Client::builder().proxy(proxy.clone()),
+                None => Client::builder(),
+            };
+
+            client_builder
+                .build()
+                .expect("clinet build error")
                 .get(endpoint)
                 .query(&[
                     ("action", "query"),


### PR DESCRIPTION
Issue Link: https://github.com/Builditluc/wiki-tui/issues/261

### Changed files:

#### wiki-api/cargo.toml:

- Add feature "socks" for reqwest.

#### src/cli.rs: 

- Add `proxy: Option<String>` for Cli struct.
- Add 'warn_list: Vec<String>' for CliResults, because it can't use tracing and log when match cli and the operation of initial proxy maybe failed.
- Add proxy initial code in `match_cli()`.

#### src/main.rs:

- Add code for warning `CliResults.warn_list`.

#### new file: wiki-api/src/proxy.rs

- `static proxy: OnceLock<Proxy>`: ensure proxy.
- 'fn validate_proxy` : check proxy address.
- `pub fn init_proxy`: initial proxy and it can only be used once.
- `pub fn get_proxy`: get proxy.

#### wiki-api/page.rs and wiki-api/search.rs

- replace `Client::new` to `Client::builder` and add proxy setting.